### PR TITLE
👷 (GitHub): disable fail-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     # PLATFORMIO_BUILD_DIR: ./../build
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
         example:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           cp -ru build/${{ matrix.board }}/* examples/${{ matrix.example }}
 
       - name: Run simulation
-        uses: leon0399/wokwi-ci-action@main
+        uses: wokwi/wokwi-ci-action@1.2.0
         with:
           token: ${{ secrets.WOKWI_CLI_TOKEN }}
           timeout: 60000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           cp -ru build/${{ matrix.board }}/* examples/${{ matrix.example }}
 
       - name: Run simulation
-        uses: wokwi/wokwi-ci-action@1.2.0
+        uses: wokwi/wokwi-ci-action@v1.2.0
         with:
           token: ${{ secrets.WOKWI_CLI_TOKEN }}
           timeout: 60000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "examples/**/*"
       - "src/**/*"
+      - ".github/workflows/**/*"
   push:
     branches:
       - master


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Disables the fail-fast option in GitHub Actions CI workflow to allow all matrix jobs to complete regardless of individual failures.

- Added `fail-fast: false` to the CI workflow strategy configuration in `.github/workflows/ci.yml` to ensure all matrix combinations run to completion even if some fail.
- This change improves debugging capabilities by providing complete test results across all platforms and examples rather than stopping at the first failure.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->