### PR TITLE
👷 (GitHub): run Wokwi for ESP32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
           - "PCA9685/VibroPulse"
           - "MPU6050/BasicReadings"
           - "MAX170XX/Simple"
-        boards: [ [ uno, esp32dev ] ]
+        board:
+          - uno
+          - esp32dev
 
     steps:
       - uses: actions/checkout@v4
@@ -41,10 +43,17 @@ jobs:
           echo "device=$DEVICE" >> "$GITHUB_OUTPUT"
 
           # check if example folder contains a wokwi.toml file
-          SHOULD_UPLOAD_ARTIFACTS=$(test -f "examples/${{ matrix.example }}/wokwi.toml" && echo "true" || echo "false")
+          HAS_WOKWI=$(test -f "examples/${{ matrix.example }}/wokwi.toml" && echo "true" || echo "false")
+          
+          # check if example folder contains a diagram.${{ matrix.board }}.json file
+          HAS_DIAGRAM=$(test -f "examples/${{ matrix.example }}/diagram.${{ matrix.board }}.json" && echo "true" || echo "false")
+          
+          # if both files exist, set SHOULD_UPLOAD_ARTIFACTS to true
+          SHOULD_UPLOAD_ARTIFACTS=$(( $HAS_WOKWI == "true" && $HAS_DIAGRAM == "true" ) && echo "true" || echo "false")
+          
           echo "upload_artifact=$SHOULD_UPLOAD_ARTIFACTS" >> "$GITHUB_OUTPUT"
           
-          ARTIFACT_NAME=$(echo "${{ matrix.example }}" | tr '/' '-')
+          ARTIFACT_NAME=$(echo "${{ matrix.example }}.${{ matrix.board }}" | tr '/' '-')
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
           
           # mkdtemp
@@ -86,7 +95,7 @@ jobs:
         run: |
           # for whatever reason, if we specify the build dir, it doesn't work
           # mkdir -p ${{ env.PLATFORMIO_BUILD_DIR }}
-          pio ci --lib="." --board=${{ join(matrix.boards, ' --board=') }} --keep-build-dir 2>&1 | tee output.log
+          pio ci --lib="." --board=${{ matrix.board }} --keep-build-dir 2>&1 | tee output.log
           
           export PLATFORMIO_BUILD_DIR=$(grep -oP 'The following files/directories have been created in \K.*' output.log)
           echo "PLATFORMIO_BUILD_DIR=$PLATFORMIO_BUILD_DIR" >> "$GITHUB_ENV"
@@ -110,12 +119,16 @@ jobs:
     needs: platformio
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
 
-        include:
-          - example: "MPU6050/BasicReadings"
-          - board: uno
+        example:
+          - "MPU6050/BasicReadings"
+
+        board:
+          - uno
+          - esp32dev
 
     steps:
       - uses: actions/checkout@v4
@@ -123,7 +136,7 @@ jobs:
       - name: Prepare metadata
         id: metadata
         run: |
-          ARTIFACT_NAME=$(echo "${{ matrix.example }}" | tr '/' '-')
+          ARTIFACT_NAME=$(echo "${{ matrix.example }}.${{ matrix.board }}" | tr '/' '-')
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
 
       - uses: actions/download-artifact@v4

--- a/examples/MPU6050/BasicReadings/diagram.esp32dev.json
+++ b/examples/MPU6050/BasicReadings/diagram.esp32dev.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "author": "Leonid Meleshin",
+  "editor": "wokwi",
+  "parts": [
+    { "type": "board-esp32-devkit-c-v4", "id": "esp", "top": -57.6, "left": -148.76, "attrs": {} },
+    { "type": "wokwi-mpu6050", "id": "imu1", "top": 109.42, "left": 21.52, "attrs": {} }
+  ],
+  "connections": [
+    [ "esp:TX", "$serialMonitor:RX", "", [] ],
+    [ "esp:RX", "$serialMonitor:TX", "", [] ],
+    [ "esp:21", "imu1:SDA", "green", [ "h0" ] ],
+    [ "esp:22", "imu1:SCL", "green", [ "h0" ] ]
+  ],
+  "dependencies": {}
+}


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Adds ESP32 support to the CI workflow by including ESP32-specific Wokwi simulation diagrams and updating the artifact handling logic.

- Added `diagram.esp32dev.json` for the MPU6050/BasicReadings example to define ESP32-specific pin connections and component layout.
- Modified CI workflow to check for board-specific diagram files and include the board type in artifact names.
- Added ESP32 to the test matrix for the MPU6050/BasicReadings example in the Wokwi simulation job.
- Updated artifact upload/download logic to handle board-specific artifacts correctly.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->